### PR TITLE
fixed multiple issues with EC ids

### DIFF
--- a/votes/battersea-votes.csv
+++ b/votes/battersea-votes.csv
@@ -2,5 +2,5 @@ Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
 2015-05-07,Battersea,E14000549,http://statistics.data.gov.uk/doc/statistical-geography/E14000549,Conservative Party,PP52,26730
 2015-05-07,Battersea,E14000549,http://statistics.data.gov.uk/doc/statistical-geography/E14000549,Labour Party,PP53,18792
 2015-05-07,Battersea,E14000549,http://statistics.data.gov.uk/doc/statistical-geography/E14000549,Liberal Democrats,PP90,2241
-2015-05-07,Battersea,E14000549,http://statistics.data.gov.uk/doc/statistical-geography/E14000549,Green Party,PP305,1682
+2015-05-07,Battersea,E14000549,http://statistics.data.gov.uk/doc/statistical-geography/E14000549,Green Party,PP63,1682
 2015-05-07,Battersea,E14000549,http://statistics.data.gov.uk/doc/statistical-geography/E14000549,UK Independence Party (UKIP),PP85,1586

--- a/votes/clwyd-south-votes.csv
+++ b/votes/clwyd-south-votes.csv
@@ -4,4 +4,4 @@ Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
 2015-05-07,Clwyd South,W07000062,http://statistics.data.gov.uk/doc/statistical-geography/W07000062,UK Independence Party (UKIP),PP85,5480
 2015-05-07,Clwyd South,W07000062,http://statistics.data.gov.uk/doc/statistical-geography/W07000062,Plaid Cymru - The Party of Wales,PP77,3620
 2015-05-07,Clwyd South,W07000062,http://statistics.data.gov.uk/doc/statistical-geography/W07000062,Liberal Democrats,PP90,1349
-2015-05-07,Clwyd South,W07000062,http://statistics.data.gov.uk/doc/statistical-geography/W07000062,Green Party,PP305,915
+2015-05-07,Clwyd South,W07000062,http://statistics.data.gov.uk/doc/statistical-geography/W07000062,Green Party,PP63,915

--- a/votes/houghton-and-sunderland-south-votes.csv
+++ b/votes/houghton-and-sunderland-south-votes.csv
@@ -1,6 +1,6 @@
 Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
-2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,Labour Party,PP 53,21218
-2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,UK Independence Party (UKIP),PP 85,8280
-2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,Conservative and Unionist Party,PP 51,7105
-2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,Green Party,PP 305,1095
-2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,Liberal Democrats,PP 90,791
+2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,Labour Party,PP53,21218
+2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,UK Independence Party (UKIP),PP85,8280
+2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,Conservative Party,PP52,7105
+2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,Green Party,PP63,1095
+2015-05-07,Houghton and Sunderland South,E14000754,http://statistics.data.gov.uk/doc/statistical-geography/E14000754,Liberal Democrats,PP90,791

--- a/votes/north-swindon-votes.csv
+++ b/votes/north-swindon-votes.csv
@@ -2,5 +2,5 @@ Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
 2015-05-07,North Swindon,E14000851,http://statistics.data.gov.uk/doc/statistical-geography/E14000851,Conservative Party,PP52,26295
 2015-05-07,North Swindon,E14000851,http://statistics.data.gov.uk/doc/statistical-geography/E14000851,Labour Party,PP53,14509
 2015-05-07,North Swindon,E14000851,http://statistics.data.gov.uk/doc/statistical-geography/E14000851,UK Independence Party (UKIP),PP85,8011
-2015-05-07,North Swindon,E14000851,http://statistics.data.gov.uk/doc/statistical-geography/E14000851,Green Party,PP305,1723
+2015-05-07,North Swindon,E14000851,http://statistics.data.gov.uk/doc/statistical-geography/E14000851,Green Party,PP63,1723
 2015-05-07,North Swindon,E14000851,http://statistics.data.gov.uk/doc/statistical-geography/E14000851,Liberal Democrats,PP90,1704

--- a/votes/nuneaton-votes.csv
+++ b/votes/nuneaton-votes.csv
@@ -2,7 +2,7 @@ Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
 2015-05-07,Nuneaton,E14000868,http://statistics.data.gov.uk/doc/statistical-geography/E14000868,Conservative Party,PP52,20827
 2015-05-07,Nuneaton,E14000868,http://statistics.data.gov.uk/doc/statistical-geography/E14000868,Labour Party,PP53,15945
 2015-05-07,Nuneaton,E14000868,http://statistics.data.gov.uk/doc/statistical-geography/E14000868,UK Independence Party (UKIP),PP85,6582
-2015-05-07,Nuneaton,E14000868,http://statistics.data.gov.uk/doc/statistical-geography/E14000868,Green Party,PP305,1281
+2015-05-07,Nuneaton,E14000868,http://statistics.data.gov.uk/doc/statistical-geography/E14000868,Green Party,PP63,1281
 2015-05-07,Nuneaton,E14000868,http://statistics.data.gov.uk/doc/statistical-geography/E14000868,Liberal Democrats,PP90,816
 2015-05-07,Nuneaton,E14000868,http://statistics.data.gov.uk/doc/statistical-geography/E14000868,Trade Unionist and Socialist Coalition,PP804,194
 2015-05-07,Nuneaton,E14000868,http://statistics.data.gov.uk/doc/statistical-geography/E14000868,English Democrats,PP17,104

--- a/votes/putney-votes.csv
+++ b/votes/putney-votes.csv
@@ -2,6 +2,6 @@ Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
 2015-05-07,Putney,E14000887,http://statistics.data.gov.uk/doc/statistical-geography/E14000887,Conservative Party,PP52,23018
 2015-05-07,Putney,E14000887,http://statistics.data.gov.uk/doc/statistical-geography/E14000887,Labour Party,PP53,12838
 2015-05-07,Putney,E14000887,http://statistics.data.gov.uk/doc/statistical-geography/E14000887,Liberal Democrats,PP90,2717
-2015-05-07,Putney,E14000887,http://statistics.data.gov.uk/doc/statistical-geography/E14000887,Green Party,PP305,2067
+2015-05-07,Putney,E14000887,http://statistics.data.gov.uk/doc/statistical-geography/E14000887,Green Party,PP63,2067
 2015-05-07,Putney,E14000887,http://statistics.data.gov.uk/doc/statistical-geography/E14000887,UK Independence Party (UKIP),PP85,1989
 2015-05-07,Putney,E14000887,http://statistics.data.gov.uk/doc/statistical-geography/E14000887,Animal Welfare Party,PP616,184

--- a/votes/sunderland-central-votes.csv
+++ b/votes/sunderland-central-votes.csv
@@ -1,7 +1,7 @@
 Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
-2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Labour Party,PP 53,20959
-2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Conservative Party,PP 52,9780
-2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,UK Independence Party (UKIP),PP 85,7997
-2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Green Party,PP 305,1706
-2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Liberal Democrats,PP 90,1105
+2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Labour Party,PP53,20959
+2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Conservative Party,PP52,9780
+2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,UK Independence Party (UKIP),PP85,7997
+2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Green Party,PP63,1706
+2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Liberal Democrats,PP90,1105
 2015-05-07,Sunderland Central,E14000982,http://statistics.data.gov.uk/doc/statistical-geography/E14000982,Independent,,215

--- a/votes/washington-and-sunderland-west-votes.csv
+++ b/votes/washington-and-sunderland-west-votes.csv
@@ -1,7 +1,7 @@
 Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
-2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Labour Party,PP 53,20478
-2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,UK Independence Party (UKIP),PP 85,7321
-2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Conservative Party,PP 52,7033
-2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Green Party,PP 305,1091
-2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Liberal Democrats,PP 90,993
-2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Trade Unionist and Socialist Coalition,PP 804,341
+2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Labour Party,PP53,20478
+2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,UK Independence Party (UKIP),PP85,7321
+2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Conservative Party,PP52,7033
+2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Green Party,PP63,1091
+2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Liberal Democrats,PP90,993
+2015-05-07,Washington and Sunderland West,E14001020,http://statistics.data.gov.uk/doc/statistical-geography/E14001020,Trade Unionist and Socialist Coalition,PP804,341

--- a/votes/wrexham-votes.csv
+++ b/votes/wrexham-votes.csv
@@ -4,5 +4,5 @@ Poll Date,Constituency,Constituency Code,Constituency URL,Party,Party ID,Votes
 2015-05-07,Wrexham,W07000044,http://statistics.data.gov.uk/doc/statistical-geography/W07000044,UK Independence Party (UKIP),PP85,5072
 2015-05-07,Wrexham,W07000044,http://statistics.data.gov.uk/doc/statistical-geography/W07000044,Plaid Cymru - The Party of Wales,PP77,2501
 2015-05-07,Wrexham,W07000044,http://statistics.data.gov.uk/doc/statistical-geography/W07000044,Liberal Democrats,PP90,1735
-2015-05-07,Wrexham,W07000044,http://statistics.data.gov.uk/doc/statistical-geography/W07000044,Green Party,PP305,669
+2015-05-07,Wrexham,W07000044,http://statistics.data.gov.uk/doc/statistical-geography/W07000044,Green Party,PP63,669
 2015-05-07,Wrexham,W07000044,http://statistics.data.gov.uk/doc/statistical-geography/W07000044,Independent,,211


### PR DESCRIPTION
* Multiple constituencies had a space in their EC IDs.
* Multiple constituencies had the incorrect Northern Irish Green Party EC ID ([PP305](http://search.electoralcommission.org.uk/English/Registrations/PP305)), instead of the Great British one ([PP63](http://search.electoralcommission.org.uk/English/Registrations/PP63))
* Houghton and Sunderland South had the Conservative Party listed as the Conservative and Unionist Party